### PR TITLE
feat + refactor: 회원가입 로직 리팩토링 및 사용자 주소 추가 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,26 @@
-import Router from "./shared/Router";
+import { ToastContainer } from 'react-toastify';
+import Router from './shared/Router';
+import { Bounce } from 'react-toastify';
 
 function App() {
-  return <Router/>;
+  return (
+    <>
+      <Router />
+      <ToastContainer
+        position="top-right"
+        autoClose={3000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick={false}
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="light"
+        transition={Bounce}
+      />
+    </>
+  );
 }
 
 export default App;

--- a/src/components/auth/AuthForm.jsx
+++ b/src/components/auth/AuthForm.jsx
@@ -1,0 +1,196 @@
+import { AUTH_INPUT_PLACEHOLDER } from '../../constants/inputPlaceholder';
+import { AUTH_MODE, BUTTON_MODE } from '../../constants/mode';
+import { Button } from '../common/Button';
+import { InputBar, InputRadio } from '../common/Input';
+import { Link } from 'react-router-dom';
+import { PATH } from '../../constants/RouterPathConstants';
+import ErrorText from '../common/ErrorText';
+import SignupAddressSelect from './SignupAddressInput';
+
+const AuthForm = ({
+  mode,
+  formData,
+  formError,
+  handleChange,
+  onSubmit,
+  handleCheckNickname,
+}) => {
+  //-----props-----
+  const { email, password, checkpassword, nickname, role } = formData;
+
+  const loginInputContents = [
+    {
+      title: 'EMAIL',
+      placeholder: AUTH_INPUT_PLACEHOLDER.EMAIL,
+      name: 'email',
+      value: email,
+      minLength: 8,
+      maxLength: 30,
+      type: 'text',
+    },
+    {
+      title: 'PASSWORD',
+      placeholder: AUTH_INPUT_PLACEHOLDER.PASSWORD,
+      name: 'password',
+      value: password,
+      minLength: 6,
+      maxLength: 12,
+      type: 'password',
+    },
+  ];
+
+  const signupInputContents = [
+    {
+      title: 'CHECK PW',
+      placeholder: AUTH_INPUT_PLACEHOLDER.CHECK_PASSWORD,
+      name: 'checkpassword',
+      value: checkpassword,
+      minLength: 6,
+      maxLength: 12,
+      type: 'password',
+      checkButton: false,
+    },
+    {
+      title: 'NICKNAME',
+      placeholder: AUTH_INPUT_PLACEHOLDER.NICKNAME,
+      name: 'nickname',
+      value: nickname,
+      minLength: 2,
+      maxLength: 8,
+      type: 'text',
+      checkButton: true,
+    },
+  ];
+
+  return (
+    <div>
+      <form onSubmit={onSubmit}>
+        {loginInputContents.map((item) => {
+          const {
+            title,
+            placeholder,
+            name,
+            value,
+            minLength,
+            maxLength,
+            type,
+          } = item;
+
+          return (
+            <label key={name}>
+              <h4>{title}</h4>
+              <InputBar
+                type={type}
+                placeholder={placeholder}
+                name={name}
+                value={value}
+                onChange={handleChange}
+                minLength={minLength}
+                maxLength={maxLength}
+              />
+              {formError[name] && <ErrorText>{formError[name]}</ErrorText>}
+            </label>
+          );
+        })}
+        {/* 회원가입 모드 : 비밀번호 확인/닉네임/주소 input 추가 */}
+        {mode === AUTH_MODE.SIGNUP && (
+          <div>
+            {signupInputContents.map((item) => {
+              const {
+                title,
+                placeholder,
+                name,
+                value,
+                minLength,
+                maxLength,
+                type,
+                checkButton,
+              } = item;
+
+              return (
+                <label key={name}>
+                  <h4>{title}</h4>
+                  <InputBar
+                    type={type}
+                    placeholder={placeholder}
+                    name={name}
+                    value={value}
+                    onChange={handleChange}
+                    minLength={minLength}
+                    maxLength={maxLength}
+                  />
+                  {checkButton && (
+                    <Button
+                      mode={BUTTON_MODE.S}
+                      type="button"
+                      onClick={handleCheckNickname}
+                    >
+                      CHECK
+                    </Button>
+                  )}
+                  {formError[name] && <ErrorText>{formError[name]}</ErrorText>}
+                </label>
+              );
+            })}
+            {/* 주소 */}
+            <label>
+              <h4>ADDRESS</h4>
+              <SignupAddressSelect name="address" onChange={handleChange} />
+            </label>
+            {/* 권한 */}
+            <div>
+              <h4>ROLE</h4>
+              <label>
+                <InputRadio
+                  name="role"
+                  value="seeker"
+                  onChange={handleChange}
+                  checked={role === 'seeker'}
+                />
+                구직자
+              </label>
+
+              <label>
+                <InputRadio
+                  name="role"
+                  value="recruiter"
+                  onChange={handleChange}
+                  checked={role === 'recruiter'}
+                />
+                멘토
+              </label>
+            </div>
+          </div>
+        )}
+
+        {mode === AUTH_MODE.LOGIN ? (
+          <Button mode={BUTTON_MODE.L} type="submit">
+            로그인
+          </Button>
+        ) : (
+          <Button mode={BUTTON_MODE.L} type="submit">
+            회원가입
+          </Button>
+        )}
+      </form>
+
+      {mode === AUTH_MODE.LOGIN ? (
+        <div>
+          <p>아직 회원이 아니신가요?</p>
+          <Link to={PATH.SIGNUP} className="font-semibold text-my-main">
+            회원가입하기
+          </Link>
+        </div>
+      ) : (
+        <div>
+          <p>회원이신가요?</p>
+          <Link to={PATH.LOGIN} className="font-semibold text-my-main">
+            로그인하기
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AuthForm;

--- a/src/components/auth/SignupAddressInput.jsx
+++ b/src/components/auth/SignupAddressInput.jsx
@@ -1,0 +1,25 @@
+import { AUTH_INPUT_PLACEHOLDER } from '../../constants/inputPlaceholder';
+
+const SignupAddressSelect = ({ name, onChange }) => {
+  return (
+    <select
+      name={name}
+      onChange={onChange}
+      className="h-[30px] w-3/4 rounded-3xl border-2 border-my-main pl-2 text-sm"
+    >
+      <option value="" selected disabled>
+        {AUTH_INPUT_PLACEHOLDER.ADDRESS}
+      </option>
+      <option value="서울">서울</option>
+      <option value="인천/경기">인천/경기</option>
+      <option value="대전/세종/충청">대전/세종/충청</option>
+      <option value="전북">전북</option>
+      <option value="광주/전남">광주/전남</option>
+      <option value="대구/경북">대구/경북</option>
+      <option value="부산/울산/경남">부산/울산/경남</option>
+      <option value="강원">강원</option>
+    </select>
+  );
+};
+
+export default SignupAddressSelect;

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,22 +1,6 @@
-export const LongButton = ({ type, onClick, children }) => {
+export const Button = ({ mode, type, onClick, children }) => {
   return (
-    <button
-      className="hover:bg-my-hover h-[40px] w-64 rounded-3xl bg-my-main"
-      type={type}
-      onClick={onClick}
-    >
-      {children}
-    </button>
-  );
-};
-
-export const ShortButton = ({ type, onClick, children }) => {
-  return (
-    <button
-      className="h-[30px] w-24 rounded-3xl bg-my-main"
-      type={type}
-      onClick={onClick}
-    >
+    <button type={type} onClick={onClick} className={mode}>
       {children}
     </button>
   );

--- a/src/components/common/ErrorText.jsx
+++ b/src/components/common/ErrorText.jsx
@@ -1,0 +1,5 @@
+const ErrorText = ({ children }) => {
+  return <p className="text-xs text-red-500">{children}</p>;
+};
+
+export default ErrorText;

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -20,3 +20,16 @@ export const InputBar = ({
     />
   );
 };
+
+export const InputRadio = ({ name, value, onChange, checked }) => {
+  return (
+    <input
+      className="h-4 w-4 accent-my-main focus:ring-my-main"
+      type="radio"
+      name={name}
+      value={value}
+      onChange={onChange}
+      checked={checked}
+    />
+  );
+};

--- a/src/constants/inputPlaceholder.js
+++ b/src/constants/inputPlaceholder.js
@@ -1,0 +1,7 @@
+export const AUTH_INPUT_PLACEHOLDER = {
+  EMAIL: '이메일을 입력해주세요',
+  PASSWORD: '비밀번호(6-12자)를 입력해주세요',
+  CHECK_PASSWORD: '비밀번호 확인',
+  NICKNAME: '닉네임(2-8자)을 입력해주세요',
+  ADDRESS: '희망 근무지역을 선택해주세요',
+};

--- a/src/constants/mode.js
+++ b/src/constants/mode.js
@@ -1,0 +1,10 @@
+export const AUTH_MODE = {
+  LOGIN: 'login',
+  SIGNUP: 'signUp',
+};
+
+export const BUTTON_MODE = {
+  S: 'S',
+  M: 'M',
+  L: 'L',
+};

--- a/src/constants/toastMessages.js
+++ b/src/constants/toastMessages.js
@@ -1,0 +1,31 @@
+export const AUTH_ERROR_MESSAGES = {
+  EMAIL: {
+    BLANK: '이메일을 입력해주세요!',
+    SAME: '이미 존재하는 회원입니다!',
+    INVALIDATE: '이메일 형식에 맞춰주세요!',
+  },
+  PASSWORD: {
+    BLANK: '비밀번호는 6-12글자 여야합니다!',
+    WEEK: '취약한 비밀번호입니다!',
+    DIFFER: '비밀번호가 다릅니다!',
+  },
+  NICKNAME: {
+    BLANK: '닉네임을 입력해주세요!',
+    SAME: '동일한 닉네임이 존재합니다!',
+    LENGTH: '닉네임은 2-8글자 여야합니다!',
+    CHECK: '닉네임 중복을 확인해주세요!',
+  },
+  ADDRESS: {
+    BLANK: '근무 희망지역을 선택해주세요!',
+  },
+  ERROR: '잠시 후 다시 시도해주세요!',
+};
+
+export const AUTH_SUCCESS_MESSAGES = {
+  SIGNUP: {
+    NEW: 'PINGER 회원이 되신 것을 환영합니다!',
+    NICKNAME: '사용가능한 닉네임입니다!',
+  },
+  LOGIN: '로그인 되었습니다!',
+  LOGOUT: '로그아웃 되었습니다!',
+};

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -33,35 +33,3 @@ const useForm = (initailState = {}, validate) => {
 };
 
 export default useForm;
-
-export const validateSignUpForm = (name, value, password) => {
-  switch (name) {
-    case 'email':
-      if (value.length < 8 || !value.includes('@')) {
-        return '이메일 형식에 맞춰주세요';
-      }
-      break;
-    case 'password':
-      if (value.length < 6 || value.length > 10) {
-        return '비밀번호는 6~10자여야 합니다';
-      }
-      break;
-    case 'checkpassword':
-      if (value !== password) {
-        return '비밀번호가 다릅니다';
-      }
-      break;
-    case 'nickname':
-      if (value.length < 2 || value.length > 6) {
-        return '닉네임은 2~6자여야 합니다';
-      }
-      break;
-    case 'address':
-      if (value.length < 2 || value.length > 11) {
-        return "주소는 '구'까지만 입력해주세요";
-      }
-      break;
-    default:
-      break;
-  }
-};

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.S {
+  @apply h-[30px] w-24 rounded-3xl bg-my-main;
+}
+
+.M {
+  @apply h-[30px] w-40 rounded-3xl bg-my-main;
+}
+
+.L {
+  @apply h-[40px] w-64 rounded-3xl bg-my-main;
+}
+
+.S:hover {
+  @apply bg-my-hover;
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,25 +1,44 @@
-import { Link } from 'react-router-dom';
-import { LongButton } from '../components/common/Button';
+import { useNavigate } from 'react-router-dom';
+import AuthForm from '../components/auth/AuthForm';
+import { AUTH_MODE } from '../constants/mode';
+import useForm from '../hooks/useForm';
+import { validateLoginForm } from '../utils/validate';
+import { PATH } from '../constants/RouterPathConstants';
 
 const Login = () => {
+  //-----navigate-----
+  const navigate = useNavigate();
+
+  //-----custom hook : useForm-----
+  //input값 유효성 검사
+  const { formData, formError, handleChange, resetForm } = useForm(
+    {
+      email: '',
+      password: '',
+    },
+    validateLoginForm,
+  );
+
+  //-----로그인 로직-----
+  //유저 데이터 확인
+  const handleSubmitLogin = (e) => {
+    e.preventDefault();
+
+    //홈으로 이동
+    navigate(PATH.HOME);
+    //폼 리셋
+    resetForm();
+  };
+
   return (
     <div>
-      <form>
-        <label>
-          <h4>EMAIL</h4>
-          <input type="text" />
-        </label>
-        <label>
-          <h4>PW</h4>
-          <input type="text" />
-        </label>
-        <LongButton type="submit">로그인</LongButton>
-      </form>
-
-      <div>
-        <p>아직 회원이 아니신가요?</p>
-        <Link to="/signup">회원가입하기</Link>
-      </div>
+      <AuthForm
+        mode={AUTH_MODE.LOGIN}
+        formData={formData}
+        formError={formError}
+        handleChange={handleChange}
+        onSubmit={handleSubmitLogin}
+      />
     </div>
   );
 };

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,16 +1,22 @@
-import { Link, useNavigate } from 'react-router-dom';
-import { LongButton, ShortButton } from '../components/common/Button';
-import { InputBar } from '../components/common/Input';
-import useForm, { validateSignUpForm } from '../hooks/useForm';
-import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useForm from '../hooks/useForm';
 import { toast } from 'react-toastify';
 import supabase from '../supabase/client';
+import { PATH } from '../constants/RouterPathConstants';
+import AuthForm from '../components/auth/AuthForm';
+import { AUTH_MODE } from '../constants/mode';
+import {
+  AUTH_ERROR_MESSAGES,
+  AUTH_SUCCESS_MESSAGES,
+} from '../constants/toastMessages';
+import { validateSignUpForm } from '../utils/validate';
+import { useState } from 'react';
 
 const Signup = () => {
-  //-----state-----
-  const [isNicknameExisted, setIsNickNameExisted] = useState(false);
   //-----navigate-----
   const navigate = useNavigate();
+  //-----state-----
+  const [isNicknameExisted, setIsNickNameExisted] = useState(true);
 
   //-----custom hook : useForm-----
   //input값 유효성 검사
@@ -25,14 +31,14 @@ const Signup = () => {
     },
     validateSignUpForm,
   );
-  const { email, password, checkpassword, nickname, address, role } = formData;
+  //formData 구조분해할당
+  const { email, password, nickname, address, role } = formData;
 
-  //-----회원가입 로직-----
   //닉네임 중복 검사
   const checkNicknameExsited = async () => {
     // 예외처리 : 닉네임 빈칸
     if (!nickname.trim()) {
-      return toast.warn('닉네임을 입력해주세요!');
+      return toast.warn(AUTH_ERROR_MESSAGES.NICKNAME.BLANK);
     }
 
     try {
@@ -43,28 +49,34 @@ const Signup = () => {
         .single();
 
       if (data) {
-        toast.warn('동일한 닉네임이 존재합니다! 다른 닉네임을 작성해주세요.');
+        toast.warn(AUTH_ERROR_MESSAGES.NICKNAME.SAME);
         setIsNickNameExisted(true);
       } else {
-        toast.success('사용가능한 닉네임 입니다.');
+        toast.success(AUTH_SUCCESS_MESSAGES.SIGNUP.NICKNAME);
         setIsNickNameExisted(false);
       }
     } catch (error) {
       console.error('닉네임 중복시 오류 발생 : ', error.message);
-      toast.error('에러가 발생했습니다! 다시 시도해주세요.');
+      toast.error(AUTH_ERROR_MESSAGES.ERROR);
     }
   };
 
+  //-----회원가입 로직-----
   //유저 데이터 등록
   const handleSubmitSignUp = async (e) => {
     e.preventDefault();
-
-    //예외처리 : 중복 닉네임
+    //예외처리 : 닉네임 중복 확인
     if (isNicknameExisted) {
-      toast.warn('닉네임 중복확인을 해주세요!');
+      toast.warn(AUTH_ERROR_MESSAGES.NICKNAME.CHECK);
+      return;
+    }
+    //예외처리 : 주소선택 누락
+    if (!address) {
+      toast.warn(AUTH_ERROR_MESSAGES.ADDRESS.BLANK);
       return;
     }
 
+    //새로운 유저 데이터 => supabase auth.users에 insert
     const newUserData = {
       email,
       password,
@@ -77,151 +89,36 @@ const Signup = () => {
         },
       },
     };
-
     const { data, error } = await supabase.auth.signUp(newUserData);
 
-    //회원가입 에러코드별 예외처리
-    if (error) {
-      switch (error.message) {
-        case 'email_exists':
-          toast.warn('이미 존재하는 이메일입니다.');
-          return;
-        case 'user_already_exists':
-          toast.warn('이미 존재하는 이메일입니다.');
-          return;
-        case 'weak_password':
-          toast.warn('비밀번호가 취약합니다.');
-          return;
-        default:
-          toast.error(`${error.message}`);
-          return;
-      }
+    console.log('newUserData', newUserData);
+    //회원가입 성공
+    if (data.user) {
+      //유저 알람
+      toast.success(AUTH_SUCCESS_MESSAGES.SIGNUP.NEW);
+      //로그인 페이지로 이동
+      navigate(PATH.LOGIN);
+      //폼 리셋
+      resetForm();
     }
 
-    //회원가입 성공
-    if (data) {
-      alert('회원가입 성공');
-      //알랏은 뜨는데 토스트 문제! 왜일까
-      toast.success('PINGER 회원이 되신 것을 환영합니다!');
-      navigate('/');
-      resetForm();
+    //회원가입 실패
+    if (error) {
+      console.log('error', error.message);
+      console.log('error type', typeof error.message);
     }
   };
 
   return (
     <div>
-      <form onSubmit={handleSubmitSignUp}>
-        {/* 이메일 */}
-        <label>
-          <h4>EMAIL</h4>
-          <InputBar
-            type="text"
-            placeholder="이메일을 입력해주세요"
-            name="email"
-            value={email}
-            onChange={handleChange}
-          />
-          {formError.email && (
-            <p className="text-xs text-red-500">{formError.email}</p>
-          )}
-        </label>
-        {/* 비밀번호 */}
-        <label>
-          <h4>PW</h4>
-          <InputBar
-            type="password"
-            placeholder="비밀번호(6-10자)를 입력해주세요"
-            name="password"
-            value={password}
-            onChange={handleChange}
-            minLength={6}
-            maxLength={10}
-          />
-          {formError.password && (
-            <p className="text-xs text-red-500">{formError.password}</p>
-          )}
-        </label>
-        <label>
-          <h4>PW</h4>
-          <InputBar
-            type="password"
-            placeholder="비밀번호 확인"
-            name="checkpassword"
-            value={checkpassword}
-            onChange={handleChange}
-            minLength={6}
-            maxLength={10}
-          />
-        </label>
-        {formError.checkpassword && (
-          <p className="text-xs text-red-500">{formError.checkpassword}</p>
-        )}
-        {/* 닉네임 */}
-        <label>
-          <h4>NICKNAME</h4>
-          <InputBar
-            type="text"
-            placeholder="닉네임(2-6자)를 입력해주세요"
-            name="nickname"
-            value={nickname}
-            onChange={handleChange}
-            minLength={2}
-            maxLength={6}
-          />
-          <ShortButton onClick={checkNicknameExsited}>중복확인</ShortButton>
-        </label>
-        {formError.nickname && (
-          <p className="text-xs text-red-500">{formError.nickname}</p>
-        )}
-        {/* 주소 */}
-        <label>
-          <h4>ADDRESS</h4>
-          <InputBar
-            type="text"
-            placeholder="주소를 입력해주세요 (서울시 강남구)"
-            name="address"
-            value={address}
-            onChange={handleChange}
-          />
-          {formError.address && (
-            <p className="text-xs text-red-500">{formError.address}</p>
-          )}
-        </label>
-        {/* 권한 */}
-        <label>
-          <h4>ROLE</h4>
-          <input
-            className="h-4 w-4 accent-my-main focus:ring-my-main"
-            name="role"
-            value="seeker"
-            type="radio"
-            onChange={handleChange}
-            checked={role === 'seeker'}
-          />
-          구직자
-        </label>
-
-        <label htmlFor="">
-          <input
-            className="h-4 w-4 accent-my-main focus:ring-my-main"
-            name="role"
-            value="recruiter"
-            type="radio"
-            onChange={handleChange}
-            checked={role === 'recruiter'}
-          />
-          멘토
-        </label>
-
-        <LongButton type="submit">회원가입</LongButton>
-      </form>
-
-      <div>
-        <p>이미 회원이신가요?</p>
-        <Link to="/login" className="text-my-main">
-          로그인하기
-        </Link>
-      </div>
+      <AuthForm
+        mode={AUTH_MODE.SIGNUP}
+        formData={formData}
+        formError={formError}
+        handleChange={handleChange}
+        onSubmit={handleSubmitSignUp}
+        handleCheckNickname={checkNicknameExsited}
+      />
     </div>
   );
 };

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -1,0 +1,47 @@
+import { AUTH_ERROR_MESSAGES } from '../constants/toastMessages';
+
+export const validateSignUpForm = (name, value, password) => {
+  switch (name) {
+    case 'email':
+      if (value.length < 8 || !value.includes('@')) {
+        return AUTH_ERROR_MESSAGES.EMAIL.INVALIDATE;
+      }
+      break;
+    case 'password':
+      if (value.length < 6 || value.length > 12) {
+        return AUTH_ERROR_MESSAGES.PASSWORD.BLANK;
+      }
+      break;
+    case 'checkpassword':
+      if (value !== password) {
+        return AUTH_ERROR_MESSAGES.PASSWORD.DIFFER;
+      }
+      break;
+    case 'nickname':
+      if (value.length < 2 || value.length > 8) {
+        return AUTH_ERROR_MESSAGES.NICKNAME.LENGTH;
+      }
+      break;
+    case 'address':
+      if (value.length < 2 || value.length > 11) {
+        return "주소는 '구'까지만 입력해주세요";
+      }
+      break;
+    default:
+      break;
+  }
+};
+
+export const validateLoginForm = (name, value) => {
+  switch (name) {
+    case 'email':
+      if (value.length < 8 || !value.includes('@')) {
+        return AUTH_ERROR_MESSAGES.EMAIL.INVALIDATE;
+      }
+      break;
+    case 'password':
+      if (value.length < 6 || value.length > 10) {
+        return AUTH_ERROR_MESSAGES.PASSWORD.BLANK;
+      }
+  }
+};


### PR DESCRIPTION
## ✨ feat + refactor(#25): 회원가입 로직 리팩토링

## 🔘 Part

- [x] FE

<br/>

## 🔎 작업 내용

- `toastMessage` / `mode` / `inputPlaceholder`상수 생성
- 에러메세지로 사용할 `ErrorMessage` 컴포넌트 제작
- 로그인/회원가입 페이지에서 사용할 `AuthForm` 컴포넌트 분리
- 사용자 주소 추가 로직 구현 및 `SignupAddressInput` 컴포넌트 제작
- `useForm` 훅과 validate 로직 분리
- 공통 컴포넌트 `Button`을 mode 속성으로 조건부 렌더링하도록 리팩토링

<br/>

## 🖼️ 이미지 첨부(선택)
<img width="1440" alt="Screenshot 2025-02-28 at 5 48 12 PM" src="https://github.com/user-attachments/assets/45780290-0832-46c7-9c3d-3f4634b699b9" />

<img width="1440" alt="Screenshot 2025-02-28 at 5 47 59 PM" src="https://github.com/user-attachments/assets/1051a77b-14ad-420e-b2fd-b1e2e87fbe02" />

<br/>

## 💬 리뷰 요구사항(선택)

> 로그인 기능은 오늘 밤까지 구현 완료하겠습니다!
> 아직 회원가입 오류처리는 구현못했습니다...! Signup 페이지에서 console.log는 작업을 위해 남겨두었으니 이점 참고해주세요!

### ✔️ 이슈 닫기

Closes #25
